### PR TITLE
Adjusting codecov icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learn Tape
 [![Build Status](https://travis-ci.org/dwyl/learn-tape.png?branch=master)](https://travis-ci.org/dwyl/learn-tape)
-[![codecov](https://codecov.io/gh/dwyl/learn-tape/branch/tape/graph/badge.svg)](https://codecov.io/gh/dwyl/learn-tape)
+[![codecov](https://codecov.io/gh/dwyl/learn-tape/branch/master/graph/badge.svg)](https://codecov.io/gh/dwyl/learn-tape/branch/master)
 [![Code Climate](https://codeclimate.com/github/dwyl/learn-tape.png)](https://codeclimate.com/github/dwyl/learn-tape)
 [![devDependencies Status](https://david-dm.org/dwyl/learn-tape/dev-status.svg)](https://david-dm.org/dwyl/learn-tape?type=dev)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/learn-tape/issues)
@@ -14,7 +14,7 @@ A *Beginner's Guide* to Test Driven Development (TDD) with ***Tape***.
 
 ## *Why?*
 
-***Testing*** your code is ***essential*** to ensuring reliability.  
+***Testing*** your code is ***essential*** to ensuring reliability.
 
 There are _many_ testing frameworks so it can be
 [*difficult to choose*](https://www.ted.com/talks/barry_schwartz_on_the_paradox_of_choice?language=en),
@@ -441,28 +441,28 @@ Follow these steps to run `Tape` tests in the browser:
 We have chosen to use [`browserify`](https://www.npmjs.com/package/browserify) to do this. **(other module bundlers are
 available)**. You'll need to install it globally to access the commands that
 come with it. Enter the following command into the command line:
-`npm install browserify --save-dev`  
+`npm install browserify --save-dev`
 2. Next you have to bundle your test files. Run the following browserify
-command:  
-`node_modules/.bin/browserify test/*.js > lib/bundle.js`  
-3. Create a `test.html` file that can hold your bundle:  
-`touch lib/test.html`  
-4. Add your test script to your newly created `test.html`:  
+command:
+`node_modules/.bin/browserify test/*.js > lib/bundle.js`
+3. Create a `test.html` file that can hold your bundle:
+`touch lib/test.html`
+4. Add your test script to your newly created `test.html`:
 `echo '<script src="bundle.js"></script>' > lib/test.html`
 5. Copy the full path of your `test.html` file and then paste it into your
 browser. Open up the developer console and you should see something that looks
-like:  
+like:
 ![browser](https://cloud.githubusercontent.com/assets/12450298/19898078/79f41d30-a052-11e6-954b-8dad5fa71771.png)
 
 #### Headless Browser
 You can print our your test results to the command line instead of the browser
 by using a headless browser:
 
-1. Install [`testling`](https://www.npmjs.com/package/testling):  
-`npm install testling --save-dev`  
-2. Run the following command to print your test results in your terminal:  
-`node_modules/.bin/browserify test/*.js | node_modules/.bin/testling`  
-3. You should see something that looks like this:  
+1. Install [`testling`](https://www.npmjs.com/package/testling):
+`npm install testling --save-dev`
+2. Run the following command to print your test results in your terminal:
+`node_modules/.bin/browserify test/*.js | node_modules/.bin/testling`
+3. You should see something that looks like this:
 ![testling](https://cloud.githubusercontent.com/assets/12450298/19898553/63e0e8a0-a054-11e6-93e1-2fe4872989ed.png)
 
 ### Continuous Integration?
@@ -485,4 +485,4 @@ istanbul cover tape ./test/*.test.js
 ```
 
 #### What about front end code with Tape?
-Now that you're a pro at using Tape to test your back end code check out our [front end testing with tape guide!](https://github.com/dwyl/learn-tape/blob/master/front-end-with-tape.md) 
+Now that you're a pro at using Tape to test your back end code check out our [front end testing with tape guide!](https://github.com/dwyl/learn-tape/blob/master/front-end-with-tape.md)


### PR DESCRIPTION
Adjusting the branch name to master, that way the icon works again.

** For some reason, my sublime text changed a bunch of line breaks (I am on windows it must be it, I am not sure)